### PR TITLE
update

### DIFF
--- a/StepperDriver-V1.0.0/stepper_driver.cpp
+++ b/StepperDriver-V1.0.0/stepper_driver.cpp
@@ -29,7 +29,9 @@
 /* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Function ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 /* :::::::::::::: Constructor ::::::::::::: */
 Stepper::Stepper(){}
-Stepper::Stepper(GPIO_TypeDef *enGPIO, uint32_t enPIN, GPIO_TypeDef *dirGPIO, uint32_t dirPIN, GPIO_TypeDef *clkGPIO, uint32_t clkPIN, uint16_t  numberOfSteps, uint16_t  rpm)
+Stepper::Stepper(GPIO_TypeDef *enGPIO, uint32_t enPIN, GPIO_TypeDef *dirGPIO,
+		uint32_t dirPIN, GPIO_TypeDef *clkGPIO, uint32_t clkPIN,
+		uint16_t  numberOfSteps, uint16_t  rpm): CallBackFunk(nullptr)
 {
 
 	/* ~~~~~~~~~~~~~~~ Stepper param ~~~~~~~~~~~~~~~ */
@@ -75,7 +77,7 @@ void Stepper::SetSpeed(uint16_t rpm)
 }
 
 /* ::::::::::::::: Position ::::::::::::::: */
-void Stepper::Step(int16_t step)
+void Stepper::Step(int32_t step)
 {
 
 	/* ~~~~~~~~~~~~~~~ Check direction ~~~~~~~~~~~~~~~ */
@@ -103,8 +105,11 @@ void Stepper::Step(int16_t step)
 
 	}
 
+	if(CallBackFunk != nullptr)
+		CallBackFunk();
+
 }
-void Stepper::Step(int16_t step, StepperRun_T func)
+void Stepper::Step(int32_t step, StepperRun_T func)
 {
 
 	uint16_t count = 0;
@@ -137,10 +142,18 @@ void Stepper::Step(int16_t step, StepperRun_T func)
 
 	}
 
+	if(CallBackFunk != nullptr)
+		CallBackFunk();
+
 }
 void Stepper::StepAngle(float ang)
 {
-	Stepper::Step((int16_t)(ang / _angRatio));
+	Stepper::Step((int32_t)(ang / _angRatio));
+}
+
+void Stepper::SetCallBackAfterMovement(void (*CallBackFunk)())
+{
+	this->CallBackFunk = CallBackFunk;
 }
 
 /* ~~~~~~~~~~~~~~~~~~~~~~~~~~~ End of the program ~~~~~~~~~~~~~~~~~~~~~~~~~~ */

--- a/StepperDriver-V1.0.0/stepper_driver.h
+++ b/StepperDriver-V1.0.0/stepper_driver.h
@@ -120,6 +120,8 @@ class Stepper
 	uint16_t       _dirPIN;
 	uint16_t       _clkPIN;
 
+	void (*CallBackFunk)();
+
 	public:
 
 	/* ~~~~~~~~~~~~~~~~~~~~~~~~ Prototupe ~~~~~~~~~~~~~~~~~~~~~~~~~ */
@@ -132,11 +134,13 @@ class Stepper
 	void SetSpeed(uint16_t rpm);
 
 	/* ::::::::::::::: Position ::::::::::::::: */
-	void Step(int16_t step);
-	void Step(int16_t step, StepperRun_T func);
+	void Step(int32_t step);
+	void Step(int32_t step, StepperRun_T func);
 
 	void StepAngle(float ang);
 	void StepAngle(float ang, StepperRun_T func);
+
+	void SetCallBackAfterMovement(void (*CallBackFunk)());
 
 };
 


### PR DESCRIPTION
* Added SetCallBackAfterMovement function Allows you to set your function to be called after the motor stops. Allows you to send a notification to the device about the motor stop. example

void _CallBackAfterMovement()
{
infoHandler(&huart4, MOTOR_STOP);
}
SetCallBackAfterMovement(_CallBackAfterMovement);

* void Step(int16_t step); replaced by void Step(int32_t step); Due to the theoretical possibility of starting the motor at a large degree via void Stepper::StepAngle(float ang) {
Stepper::Step((int32_t)(ang / _angRatio));
}

with int16_t it is easy to cause an overflow

Add Acceleration